### PR TITLE
Various minor changes to the manual, mostly fixing typos 

### DIFF
--- a/src/002_installation.md
+++ b/src/002_installation.md
@@ -80,7 +80,10 @@ Mac OS X {#sec:macosx}
 
 ### Installing the pre-built Tamarin binary {#sec:MacOSBinInstall}
 
-To run Tamarin on Mac OS X you need to have Maude 2.7 and GraphViz. 
+To run Tamarin on Mac OS X you need to have Maude 2.7 and GraphViz. If you have [HomeBrew](http://brew.sh) installed, you can simply 
+`brew install homebrew/science/maude graphviz` to satisfy the pre-requisites of running the binary. Then follow from step 3 onwards.
+
+Otherwise, to install Maude and GraphViz manually:
 
 1.  Download and install Core Maude 2.7 from
   <http://maude.cs.illinois.edu/w/index.php?title=Maude_download_and_installation>.

--- a/src/004_cryptographic-messages.md
+++ b/src/004_cryptographic-messages.md
@@ -117,6 +117,8 @@ In the following, we write `f/n` to denote that the function symbol `f` is
 : This theory models a public key encryption scheme. It defines the
   function symbols `aenc/2`, `adec/2`, and `pk/1`, which are
   related by the equation `adec(aenc(m, pk(sk)), sk) = m`.
+  Note that as described in [Syntax Description](014_syntax_description.html), 
+  `aenc{x,y}pkB` is syntactic sugar for `aenc(<x,y>, pkB)`.
 
 `signing`:
 

--- a/src/004_cryptographic-messages.md
+++ b/src/004_cryptographic-messages.md
@@ -119,6 +119,7 @@ In the following, we write `f/n` to denote that the function symbol `f` is
   related by the equation `adec(aenc(m, pk(sk)), sk) = m`.
   Note that as described in [Syntax Description](014_syntax_description.html), 
   `aenc{x,y}pkB` is syntactic sugar for `aenc(<x,y>, pkB)`.
+  <!-- This is otherwise not mentioned until Ch14: Syntax Description -->
 
 `signing`:
 

--- a/src/005_protocol-specification.md
+++ b/src/005_protocol-specification.md
@@ -60,7 +60,7 @@ the transitions will be labeled. The system's state is a multiset (bag) of
 facts. We will explain the types of facts and their use below.
 
 A rewrite rule in Tamarin has a name and three parts, each of which
-is a sequence of facts: one for the rule's left-hand side, one labelleing the
+is a sequence of facts: one for the rule's left-hand side, one labelling the
 transition (which we call 'action facts'),  and one for the rule's right-hand side.
 For example:
 
@@ -311,22 +311,22 @@ to specify security properties, as we will see in the next
 section.  This leads to:
 
         rule NaxosR_attempt3:
-            let 
-                exR = h1(< ~eskR, ~lkR >)
-                hkr = 'g'^exR
-                kR  = h2(< pkI^exR, X^~lkR, X^exR, $I, $R >)
-            in
-             [
-                 In(X),
-                 Fr( ~eskR ),
-                 Fr( ~tid ),
-                 !Ltk($R, ~lkR),
-                 !Pk($I, pkI)
-             ]
-             --[ SessionKey( ~tid, $R, $I, kR ) ]->
-             [
-                 Out( hkr )
-             ]
+          let 
+              exR = h1(< ~eskR, lkR >)
+              hkr = 'g'^exR
+              kR  = h2(< pkI^exR, X^lkR, X^exR, $I, $R >)
+          in
+           [
+               In(X),
+               Fr( ~eskR ),
+               Fr( ~tid ),
+               !Ltk($R, lkR),
+               !Pk($I, pkI)
+           ]
+           --[ SessionKey( ~tid, $R, $I, kR ) ]->
+           [
+               Out( hkr )
+           ]
 
 The above rule models the responder role accurately, and computes the
 appropriate key.

--- a/src/006_property-specification.md
+++ b/src/006_property-specification.md
@@ -599,7 +599,7 @@ in with an `Honest(B)` action fact, where `B` is the agent name that
 is assumed to be honest. For instance, in the following rule the agent
 in role `'A'` is sending a message, where the nonce `~na` is supposed to be secret assuming that both agents `A` and `B` are honest.
 
-~~~~ {.tamarin slice="code/secrecy-asymm-large.spthy" lower=43 upper=52}
+~~~~ {.tamarin slice="code/secrecy-asymm-large.spthy" lower=43 upper=54}
 ~~~~
 
 We then specify the property that a message `x` is secret as long as agents

--- a/src/007_precomputation.md
+++ b/src/007_precomputation.md
@@ -130,9 +130,9 @@ responder has sent the second message before.
 Generally, in a protocol with open chains it is advisable to try if the problem
 can be solved by a typing lemma that considers where a term could be coming
 from.
-As in the above example, one idea to do so is by stating that a used term 
-must either have occured in a one of a list of rules before or it must have 
-come from the adversary.
+As in the above example, one idea to do so is by stating that a used term must
+either have occured in one of a list of rules before, or it must have come
+from the adversary.
 
 The above typing lemma can be automatically proven by Tamarin. With the typing 
 lemma, Tamarin can then automatically prove the lemma `nonce_secrecy`.

--- a/src/008_modeling-issues.md
+++ b/src/008_modeling-issues.md
@@ -49,10 +49,9 @@ message.  We express this as follows:
 If we try to prove this with Tamarin in the model with the error, the
 lemma statement will be falsified. This indicates that there exists no
 trace where the initiator sends a message to the receiver.
-Such errors arise, for example, when
-e forget to add a fact that connects several rules and
-some rules can never be reached.  Generally it is recommended to first
-prove an `exists-trace` lemma before other properties are examined.
+Such errors arise, for example, when we forget to add a fact that connects
+several rules and some rules can never be reached.  Generally it is recommended
+first to prove an `exists-trace` lemma before other properties are examined.
 
 ### Error Messages ###
 In this section, we review common error messages produced by Tamarin.
@@ -65,6 +64,10 @@ First we change the setup rule as follows:
 
 ~~~~ {.tamarin slice="code_ERRORexamples/FirstTimeUser_Error2.spthy" lower=16 upper=20}
 ~~~~
+
+Note that the the first `AgSt(...)` in the conclusion has arity three, with
+variables `$I,~k,~m`, rather than the original arity two, with variables
+`$I,<~k,~m>` where the second argument is paired.
 
 The following statement that some wellformedness check failed will
 appear at the very end of the text when loading this theory.
@@ -121,7 +124,7 @@ we get the error message
 	*/
 
 The warning `unbound variables` indicates that there is a term, here the fresh 
-`~n`, in the action or conclusion that never appeared in the premisse. 
+`~n`, in the action or conclusion that never appeared in the premise.
 Here this is the case because we mistyped `~n` instead of `~m`. Generally,
 when such a warning appears, you should check that all the fresh variables 
 variables already occur in the premise. If it is a fresh variable that appears

--- a/src/009_advanced-features.md
+++ b/src/009_advanced-features.md
@@ -13,7 +13,7 @@ Heuristics
 The commandline option `--heuristic` can be used to select which heuristic for
 goal selection should be used by the automated proof methods. 
 The argument of the `--heuristic` flag is a word built from the
-alphabet `{s,S,c,C}`. Each of these letters describes a different way to rank
+alphabet `{s,S,c,C,i}`. Each of these letters describes a different way to rank
 the open goals of a constraint system.
 
 `s`:
@@ -176,7 +176,7 @@ and `In` facts to the `Out_C` and `In_C` facts, respectively.
 
 In this modified protocol, the lemma `nonce_secret_initiator` holds. 
 As the initiator sends the nonce on a confidential channel, only the intended
-receiver can read the message, but the adversary cannot learn it.
+receiver can read the message, and the adversary cannot learn it.
 
 #### Authentic Channel Rules
 


### PR DESCRIPTION
I've caught a couple of typos, and fixed a couple of bugs. 
I've also added a couple of clarifying sentences to make things easier to understand on first read through, where e.g. when I read it, I had to read it a couple of times (and read forward a bit) before I understood what it was saying.