### PR TITLE
Manually install a newer version of pandoc than the one in apt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,23 +2,34 @@ language: generic
 script: bash ./deploy.sh
 
 # This is the Official Way to get travis to run a 14.04 build.
-# We need sudo to install texlive-xelatex for the pdf.
+# We need sudo to install texlive-xetex for the pdf.
 sudo: required
 dist: trusty
+
+# pandoc is in the apt repositories but the version is too old---specifically, it doesn't
+# support the {width=100%} syntax used in the manual. Hence, download a later release and
+# install that manually.
+before_install:
+  - wget https://github.com/jgm/pandoc/releases/download/1.19.1/pandoc-1.19.1-1-amd64.deb
+  - sudo dpkg -i pandoc-1.19.1-1-amd64.deb
+
+# Dependencies for the compile
 addons:
   apt:
     packages:
-    - pandoc
-    - pandoc-citeproc
     - texlive-xetex
     - texlive-latex-extra
     - texlive-fonts-recommended
     - latex-xcolor
     - lmodern
+
+# ENCRYPTION_LABEL is used in the deploy script to identify which keys can push to the repo
 env:
   global:
   - ENCRYPTION_LABEL: 6fcf0ddd2a20
   - COMMIT_AUTHOR_EMAIL: deploy@travis-ci.org
+
+# Cas's Slack gets notified when a build completes
 notifications:
   slack:
     secure: 2AwqKuNcjdUO/g0PmVZm0VLJ70qiT+rz7fIiSp9huUW5QEYM9LNti9+etInM6giUwMLo9Y8ieKipkxXVFeg6u2IIzozki3MsemIKPLWlQrTsuaitAAuA7Uf/O2T+f6YTA/nyxCK57v+eYk7DYL+QsRo1EzQOmvSxS12JTjb22Z4OdoP4+YtH2Fp+GZNVxpfDV3hg7NBeYbpSf6eMVhxmYNBM/NjhXYMiCN4Ubys/x3ITyd2SUgZ+VuaciUfhhcISov+1GroP27Ql+wI4KjXgxYsnhfzxOPtgEhCkVHJw3dN124Iie3Nl4ogabA9FD4rVuHjJYz9YwguBhPv3Ndq3hkFwf/t561SlihLnxQT1aJrNZjmQnddDoMo2vt47DUAjkmRnyUYQSkRbaz8uIWp7DfRjyHtCQxCBZ4CKo7alTrMrvKEaDeqzKQFjoKJMKfIzKpliRnQWhd92k3vN/+/tCutRJ47g6HAs5M3TbjEeKruqS6xiNgVj3RoMAajmjiiv3gKbpIjVkVW+6t5tK1ssMv4WaRFAN4PmFJD/SxKTjrLjcUrZGA4QDJbpsl3VUSE+ot9ZNuzC6E03obB8Ewnm9cWYSMwPyZkd72ySoaF+LsO4YwsgbrfGfnesSFoL0lCrwSHR7H9ZnpWexrocDCBUy4BDqwKYTih2Rzs6r9UHUww=


### PR DESCRIPTION
The version in apt doesn't understand [img]{width=100%} which is used in the manual. They have a tagged release on github, so instead we can ask travis to fetch and install that.