### PR TITLE
Add comment about use of --quit-on-warning to 003_example.md

### DIFF
--- a/src/003_example.md
+++ b/src/003_example.md
@@ -482,6 +482,26 @@ attached (dis)proofs:
       Client_auth_injective (all-traces): verified (15 steps)
       Client_session_key_honest_setup (exists-trace): verified (5 steps)
 
+
+### Quit on Warning
+
+As referred to in ["Graphical User Interface"](#sec:gui), in larger models, it's
+very easy to miss wellformedness errors (when writing the Tamarin file, and when
+running the `tamarin-prover`), especially as a long list of pre-computation
+output-text flies past on the terminal: in many cases, the web-server starts up
+correctly, making it harder to notice that something's not right either in a
+rule or lemma.
+
+To ensure that your provided `.spthy` file is free of any errors or warnings
+(and to halt pre-processing and other computation in the case of errors), it can
+be a good idea to use the `--quit-on-warning` flag at the command line. E.g.
+
+    tamarin-prover interactive FirstExample.spthy --quit-on-warning
+
+This will stop Tamarin's computations any further, and leave the error or
+warning causing Tamarin to stop on the terminal.
+
+
 Complete Example
 ----------------
 

--- a/src/003_example.md
+++ b/src/003_example.md
@@ -485,21 +485,19 @@ attached (dis)proofs:
 
 ### Quit on Warning
 
-As referred to in ["Graphical User Interface"](#sec:gui), in larger models, it's
-very easy to miss wellformedness errors (when writing the Tamarin file, and when
-running the `tamarin-prover`), especially as a long list of pre-computation
-output-text flies past on the terminal: in many cases, the web-server starts up
-correctly, making it harder to notice that something's not right either in a
-rule or lemma.
+As referred to in ["Graphical User Interface"](#sec:gui), in larger models, one
+can miss wellformedness errors (when writing the Tamarin file, and when running
+the `tamarin-prover`): in many cases, the web-server starts up correctly, making
+it harder to notice that something's not right either in a rule or lemma.
 
 To ensure that your provided `.spthy` file is free of any errors or warnings
 (and to halt pre-processing and other computation in the case of errors), it can
-be a good idea to use the `--quit-on-warning` flag at the command line. E.g.
+be a good idea to use the `--quit-on-warning` flag at the command line. E.g.,
 
     tamarin-prover interactive FirstExample.spthy --quit-on-warning
 
-This will stop Tamarin's computations any further, and leave the error or
-warning causing Tamarin to stop on the terminal.
+This will stop Tamarin's computations from progressing any further, and leave
+the error or warning causing Tamarin to stop on the terminal.
 
 
 Complete Example


### PR DESCRIPTION
As discussed by [issue 243](https://github.com/tamarin-prover/tamarin-prover/issues/243).

Feel free to edit the text, or move it to a better location in this file. I think it should remain in the `003_example.md` file (or somewhere similarly early, rather than `009_advanced-features.md`) as I have heard examples of beginners not knowing they had wellformedness errors, and then wondering why they couldn't prove anything.