### PR TITLE
Add installation instructions for Nix/NixOS users

### DIFF
--- a/src/002_installation.md
+++ b/src/002_installation.md
@@ -74,6 +74,14 @@ There is a package in the official repositories. To install it, simply type:
 
   * `pacman -S tamarin-prover`
 
+### Automatic Installation for Nix/NixOS {#sec:NixBinInstall}
+
+There is a package in the official Nixpkgs repository. To install it, simply type:
+
+  * `nix-env -i tamarin-prover`
+
+This installs a per-user copy of Tamarin. If you're on NixOS, just add `tamarin-prover` to your
+`environment.systemPackages` for system-wide installation.
 
 Mac OS X {#sec:macosx}
 --------


### PR DESCRIPTION
As of a recent version of Nixpkgs, `tamarin-prover` is a maintained, upstream package, along with Maude/SAPIC configured for it, out of the box. We're using a recent snapshot version of tamarin 1.3.0 from the `develop` branch, built with GHC 8.2.2. I've tested the TLS handshake examples with this build which seems to work fine.

This simply adds manual instructions that Nix/NixOS users will be familiar with.