### PR TITLE
Add license to MarkDown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,12 @@ The source files can be found in the `src` directory.
 ## Prerequisites
 
 To compile the manual, you need [pandoc](http://pandoc.org) and pandoc-citeproc.
-We recommend to use [stack](www.haskellstack.org/) to install these dependencies.
+We recommend to use [stack](https://www.haskellstack.org/) to install these dependencies.
 
     stack install pandoc pandoc-citeproc
+
+(If you get any errors while running this, make sure you're running the latest version of Stack: 
+`stack update && stack upgrade` then try again.)
 
 To create the PDF, [xelatex](http://xetex.sourceforge.net/) is required,
 which is part of the texlive packages. On Ubuntu/Debian systems it can

--- a/src/001_introduction.md
+++ b/src/001_introduction.md
@@ -125,3 +125,21 @@ described in Section
 manual with contact information and further reading in [Contact
 Information and Further
 Reading](013_contact-and-further-reading.html#sec:contact).
+
+
+License
+-------
+
+Tamarin Prover Manual, by The Tamarin Team.
+Copyright © 2016.
+
+[tamarin-prover.github.io](https://tamarin-prover.github.io)
+
+
+This written work is licensed under a Creative Commons Attribution-NonCommercial-ShareAlike 4.0
+International License. You may reproduce and edit this work with attribution for all non-commercial
+purposes.
+
+
+References
+----------

--- a/templates/template.latex
+++ b/templates/template.latex
@@ -230,7 +230,7 @@ by The Tamarin Team
 
 \par
 Copyright \copyright\ 2016. \\
-\href{http://tamarin-prover.github.io}{tamarin-prover.github.io}
+\href{https://tamarin-prover.github.io}{tamarin-prover.github.io}
 
 \par
 This written work is licensed under a Creative Commons


### PR DESCRIPTION
As discussed in my [issue](https://github.com/tamarin-prover/manual/issues/33), I have now added the CC BY-NC-SA license to the `001_introduction.md` file so that this license makes its way clearly into the HTML version of the manual. This does mean that the license is detailed twice in the PDF, but I don't think this is a problem.

I've also fixed a couple of other v minor issues in the repo.