### PR TITLE
Fixed secrecy_asym_enc example in section 6

### DIFF
--- a/code/secrecy-asymm.spthy
+++ b/code/secrecy-asymm.spthy
@@ -5,46 +5,46 @@ builtins: asymmetric-encryption
 
 /* We formalize the following protocol:
 
-    1. A -> B: {A,na}sk(A)
+    1. A -> B: {A,na}pk(B)
 
 */
 
 // Public key infrastructure
 rule Register_pk:
-  [ Fr(~ltkA) ]
+  [ Fr(~ltkE) ]
   -->
-  [ !Ltk($A, ~ltkA)
-  , !Pk($A, pk(~ltkA))
-  , Out(pk(~ltkA)) 
+  [ !Ltk($E, ~ltkE)
+  , !Pk($E, pk(~ltkE))
+  , Out(pk(~ltkE)) 
   ] 
 
 // Compromising an agent's long-term key
 rule Reveal_ltk:
-  [ !Ltk(A, ltkA) ] --[ Reveal(A) ]-> [ Out(ltkA) ]
+  [ !Ltk(E, ltkE) ] --[ Reveal(E) ]-> [ Out(ltkE) ]
 
 // Role A sends first message
 rule A_1_send:
   [ Fr(~na)
-  , !Ltk(A, ltkA)
-  , !Pk(B, pkB)
+  , !Ltk($A, ltkA)
+  , !Pk($B, pkB)
   ]
---[ Send(A, aenc(<A, ~na>, pkB)) 
-  , Secret(~na), Honest(A), Honest(B), Role('A')
+--[ Send($A, aenc(<$A, ~na>, pkB)) 
+  , Secret(~na), Honest($A), Honest($B), Role('A')
   ]->
-  [ St_A_1(A, ltkA, pkB, B, ~na) 
-  , Out(aenc(<A, ~na>, pkB))
+  [ St_A_1($A, ltkA, pkB, $B, ~na) 
+  , Out(aenc(<$A, ~na>, pkB))
   ]
 
 // Role B receives first message
 rule B_1_receive:
-  [ !Ltk(B, ltkB)
-  , !Pk(A, pkA)
-  , In(aenc(<A, na>,pkB))
+  [ !Ltk($B, ltkB)
+  , !Pk($B, pkB)
+  , In(aenc(<$A, na>,pkB))
   ]
---[ Recv(B, aenc(<A, na>, pkB)) 
-  , Secret(na), Honest(B), Honest(A), Role('B')
+--[ Recv($B, aenc(<$A, na>, pkB)) 
+  , Secret(na), Honest($B), Honest($A), Role('B')
   ]->
-  [ St_B_1(B, ltkB, pkA, A, na)
+  [ St_B_1($B, ltkB, $A, na)
   ]
 
 lemma executable:


### PR DESCRIPTION
See: https://tamarin-prover.github.io/manual/book/006_property-specification.html#secrecy

From working the example secrecy_asym_enc in this section of chapter 6 I believe it to be wrong and it contains numerous errors resulting in an attack being found, which I believe to be incorrect. it shows the following trace:
![broken](https://user-images.githubusercontent.com/1949133/44587771-da637f00-a7ab-11e8-9cfd-60ac50b9a234.png)

When fixed it shows the obvious and correct attack:
![fixed](https://user-images.githubusercontent.com/1949133/44587787-ebac8b80-a7ab-11e8-9a19-895c6b990795.png)

See the PR for the minimal changes and from reading the manual this has no impact on the text.
