### PR TITLE
Fixed auth_signing_simple example in section 6

### DIFF
--- a/code/auth-signing-simple.spthy
+++ b/code/auth-signing-simple.spthy
@@ -5,43 +5,45 @@ builtins: asymmetric-encryption
 
 /* We formalize the following protocol:
 
-    1. A -> B: {A,na}sk(A)
+    1. A -> B: {A,na}pk(B)
 
 */
 
 // Public key infrastructure
 rule Register_pk:
-  [ Fr(~ltkA) ]
+  [ Fr(~ltkE) ]
   -->
-  [ !Ltk($A, ~ltkA)
-  , !Pk($A, pk(~ltkA))
-  , Out(pk(~ltkA)) 
+  [ !Ltk($E, ~ltkE)
+  , !Pk($E, pk(~ltkE))
+  , Out(pk(~ltkE)) 
   ] 
 
 // Role A sends first message
 rule A_1_send:
-  let m = <A, ~na>
+  let m = <$A, ~na>
   in 
   [ Fr(~na)
-  , !Ltk(A, ltkA)
-  , !Pk(B, pkB)
+  , !Ltk($A, ltkA)
+  , !Pk($B, pkB)
   ]
---[ Send(A, m) 
+--[ Send($A, m) 
   ]->
-  [ St_A_1(A, ltkA, pkB, B, ~na) 
-  , Out(aenc(m,ltkA))
+  [ St_A_1($A, ltkA, pkB, $B, ~na) 
+  , Out(aenc(m,pkB))
   ]
 
 // Role B receives first message
 rule B_1_receive:
-  [ !Ltk(B, ltkB)
-  , !Pk(A, pk(skA))
-  , In(aenc(m,skA))
+  let m = <$A, na>
+  in
+  [ !Ltk($B, ltkB)
+  , !Pk($B, pkB)
+  , In(aenc(m,pkB))
   ]
---[ Recv(B, m)
-  , Authentic(A,m), Honest(B), Honest(A)
+--[ Recv($B, m)
+  , Authentic($A,m), Honest($B), Honest($A)
   ]->
-  [ St_B_1(B, ltkB, pk(skA), A, m)
+  [ St_B_1($B, ltkB, $A, m)
   ]
 
 lemma executable:

--- a/code/auth-signing-simple.spthy
+++ b/code/auth-signing-simple.spthy
@@ -5,45 +5,39 @@ builtins: asymmetric-encryption
 
 /* We formalize the following protocol:
 
-    1. A -> B: {A,na}pk(B)
+    1. A -> B: {A,na}sk(A)
 
 */
 
 // Public key infrastructure
 rule Register_pk:
-  [ Fr(~ltkE) ]
+  [ Fr(~ltkA) ]
   -->
-  [ !Ltk($E, ~ltkE)
-  , !Pk($E, pk(~ltkE))
-  , Out(pk(~ltkE)) 
+  [ !Ltk($A, ~ltkA)
+  , !Pk($A, pk(~ltkA))
+  , Out(pk(~ltkA)) 
   ] 
 
 // Role A sends first message
 rule A_1_send:
-  let m = <$A, ~na>
-  in 
   [ Fr(~na)
   , !Ltk($A, ltkA)
-  , !Pk($B, pkB)
   ]
---[ Send($A, m) 
+--[ Send($A, <$A, ~na>) 
   ]->
-  [ St_A_1($A, ltkA, pkB, $B, ~na) 
-  , Out(aenc(m,pkB))
+  [ St_A_1($A, ltkA, ~na) 
+  , Out(aenc(<$A, ~na>,ltkA))
   ]
 
 // Role B receives first message
 rule B_1_receive:
-  let m = <$A, na>
-  in
-  [ !Ltk($B, ltkB)
-  , !Pk($B, pkB)
-  , In(aenc(m,pkB))
+  [ !Pk($A, pk(skA))
+  , In(aenc(<$A, na>,skA))
   ]
---[ Recv($B, m)
-  , Authentic($A,m), Honest($B), Honest($A)
+--[ Recv($B, <$A, na>)
+  , Authentic($A,<$A, na>), Honest($B), Honest($A)
   ]->
-  [ St_B_1($B, ltkB, $A, m)
+  [ St_B_1($B, pk(skA), $A, <$A, na>)
   ]
 
 lemma executable:

--- a/code/auth-signing-simple.spthy
+++ b/code/auth-signing-simple.spthy
@@ -11,11 +11,11 @@ builtins: asymmetric-encryption
 
 // Public key infrastructure
 rule Register_pk:
-  [ Fr(~ltkA) ]
+  [ Fr(~ltkX) ]
   -->
-  [ !Ltk($A, ~ltkA)
-  , !Pk($A, pk(~ltkA))
-  , Out(pk(~ltkA)) 
+  [ !Ltk($X, ~ltkX)
+  , !Pk($X, pk(~ltkX))
+  , Out(pk(~ltkX)) 
   ] 
 
 // Role A sends first message


### PR DESCRIPTION
See: https://tamarin-prover.github.io/manual/book/006_property-specification.html#sec:message-authentication
Related Issue: https://github.com/tamarin-prover/manual/pull/46

From working the example auth_signing_simple in this section of chapter 6 I believe it to be wrong and it contains numerous errors resulting in an attack being found, which I believe to be incorrect. it shows the following trace:
![broken2](https://user-images.githubusercontent.com/1949133/44588295-34b10f80-a7ad-11e8-8d25-5bc42b005231.png)

When fixed it shows the obvious and correct attack:
![fixed2](https://user-images.githubusercontent.com/1949133/44588312-3ed30e00-a7ad-11e8-9bdf-d4a0daa84248.png)
