### PR TITLE
Fixes to grammar

### DIFF
--- a/src/009_advanced-features.md
+++ b/src/009_advanced-features.md
@@ -83,7 +83,8 @@ in a round-robin fashion depending on the proof-depth. For example, a flag
 'Consecutive' goal ranking. The idea is that you can mix goal rankings easily
 in this way.
 
-### Fact Annotations
+Fact annotations {#sec:fact-annotations}
+-------------------
 
 Facts can be annotated with `+` or `-` to influence their priority in heuristics.
 Annotating a fact with `+` causes the tool to solve instances of that fact

--- a/src/014_syntax_description.md
+++ b/src/014_syntax_description.md
@@ -33,7 +33,7 @@ sets of function definitions and subterm convergent equations. They are
 expanded upon parsing and you can therefore inspect them by pretty printing
 the file using `tamarin-prover your_file.spthy`. The built-in `diffie-hellman`
 is special. It refers to the equations given in Section [Cryptographic
-Messages](004_cryptographic-messages.html#equational-theories). You need to 
+Messages](004_cryptographic-messages.html#sec:equational-theories). You need to
 enable it to parse terms containing exponentiations, e.g.,  g ^ x.
 
     built_in       := 'builtins' ':' built_ins (',' built_ins)*
@@ -92,8 +92,9 @@ quantifier.
              [trace_quantifier]
              '"' formula '"'
              proof_skeleton
-    lemma_attrs      := '[' ('sources' | 'reuse' | 'use_induction' | 
-                             'hide_lemma=' ident | 'heuristic=' ident) ']'
+    lemma_attrs      := '[' lemma_attr (',' lemma_attr)* ']'
+    lemma_attr       := 'sources' | 'reuse' | 'use_induction' |
+                             'hide_lemma=' ident | 'heuristic=' ident
     trace_quantifier := 'all-traces' | 'exists-trace'
 
 In observational equivalence mode, lemmas can be associated to one side.
@@ -177,7 +178,14 @@ exponentiation tags. See the `loops/Crypto_API_Simple.spthy` example for more
 information.
 
     facts := fact (',' fact)*
-    fact := ['!'] ident '(' [msetterm (',' msetterm)*] ')'
+    fact  := ['!'] ident '(' [msetterm (',' msetterm)*] ')' [fact_annotes]
+    fact_annotes := '[' fact_annote (',' fact_annote)* ']'
+    fact_annote  := '+' | '-' | 'no_precomp'
+
+Fact annotations can be used to adjust the priority of corresponding
+goals in the heuristics, or influence the precomputation step performed by
+Tamarin, as described in
+Section [Advanced Features](009_advanced-features.html#sec:fact-annotations).
 
 Formulas are trace formulas as described previously. Note that we are a bit
 more liberal with respect to guardedness. We accept a conjunction of atoms as

--- a/src/014_syntax_description.md
+++ b/src/014_syntax_description.md
@@ -13,7 +13,7 @@ All security protocol theory are named and delimited by `begin` and `end`.
 We explain the non-terminals of the body in the following paragraphs.
 
     security_protocol_theory := 'theory' ident 'begin' body 'end'
-    body := (signature_spec | rule | restriction | lemma | formal_comment)+
+    body := (signature_spec | rule | restriction | lemma | formal_comment)*
 
 Here, we use the term signature more liberally to denote both the defined
 function symbols and the equalities describing their interaction.  Note that
@@ -21,11 +21,14 @@ our parser is stateful and remembers what functions have been defined. It will
 only parse function applications of defined functions.
 
     signature_spec := functions | equations | built_in
-    functions      := 'functions' ':' (ident '/' arity) list
-    equations      := 'equations' ':' (term '=' term) list
+    functions      := 'functions' ':' function_sym (',' function_sym)*
+    function_sym   := ident '/' arity ['[private]']
     arity          := digit+
+    equations      := 'equations' ':' equation (',' equation)*
+    equation       := (term '=' term)
 
-Note that the equations must be subterm-convergent. Tamarin provides built-in
+Note that the equations must be subterm-convergent, and do not allow the use
+of fixed public names in the terms. Tamarin provides built-in
 sets of function definitions and subterm convergent equations. They are
 expanded upon parsing and you can therefore inspect them by pretty printing
 the file using `tamarin-prover your_file.spthy`. The built-in `diffie-hellman`
@@ -33,20 +36,25 @@ is special. It refers to the equations given in Section [Cryptographic
 Messages](004_cryptographic-messages.html#equational-theories). You need to 
 enable it to parse terms containing exponentiations, e.g.,  g ^ x.
 
-    built_in       := 'builtins' ':' built_ins list
+    built_in       := 'builtins' ':' built_ins (',' built_ins)*
     built_ins      := 'diffie-hellman'
                     | 'hashing' | 'symmetric-encryption'
                     | 'asymmetric-encryption' | 'signing'
+                    | 'bilinear-pairing' | 'xor'
+                    | 'multiset' | 'revealing-signing'
 
 Multiset rewriting rules are specified as follows. The protocol corresponding
 to a security protocol theory is the set of all multiset rewriting rules
 specified in the body of the theory.
 
-    rule := 'rule' ident [rule_anot] ':'
+    rule := 'rule' [modulo] ident [rule_attrs] ':'
             [let_block]
             '[' facts ']' ( '-->' | '--[' facts ']->') '[' facts ']'
-    rule_anot := '[' ('color=' | 'colour=') hexcolor ']'
-    let_block := 'let' (ident '=' term)+ 'in'
+    modulo     := '(' 'modulo' ('E' | 'AC') ')'
+    rule_attrs := '[' rule_attr (',' rule_attr)* ']'
+    rule_attr  := ('color=' | 'colour=') hexcolor
+    let_block  := 'let' (msg_var '=' msetterm)+ 'in'
+    msg_var    := identifier ['.' natural] [':' 'msg']
 
 Rule annotations do not influence the rule's semantics. A color is represented
 as a triplet of 8 bit hexadecimal values optionally
@@ -80,19 +88,37 @@ interpreted as a property that must hold for all traces of the protocol of the
 security protocol theory. You can change this using the 'exists-trace' trace
 quantifier.
 
-    lemma := 'lemma' ident [lemma_attrs] ':'
+    lemma := 'lemma' [modulo] ident [lemma_attrs] ':'
              [trace_quantifier]
              '"' formula '"'
-             proof
+             proof_skeleton
     lemma_attrs      := '[' ('sources' | 'reuse' | 'use_induction' | 
-                             'hide_lemma=' ident) ']'
+                             'hide_lemma=' ident | 'heuristic=' ident) ']'
     trace_quantifier := 'all-traces' | 'exists-trace'
     proof            := ... a proof as output by the Tamarin prover ..
 
 In observational equivalence mode, lemmas can be associated to one side.
 
     lemma_attrs      := '[' ('sources' | 'reuse' | 'use_induction' | 
-                             'hide_lemma=' ident | 'left' | 'right') ']'
+                             'hide_lemma=' ident | 'heuristic=' ident |
+                             'left' | 'right') ']'
+
+A proof skeleton is a complete or partial proof as output by the Tamarin prover.
+It indicates the proof method used at each step, which may include multiple cases.
+
+    proof_skeleton :=  'SOLVED' | 'by' proof_method
+                    | proof_method proof_skeleton
+                    | proof_method 'case' identifier proof_skeleton
+                        ('next 'case' identifier proof_skeleton)* 'qed'
+    proof_method   := 'sorry' | 'simplify' | 'solve '(' goal ')' |
+                      'contradiction' | 'induction'
+    goal           :=  fact "▶" natural_subscr node_var
+                    | fact '@' node_var
+                    | '(' node_var ',' natural ')' '~~>' '(' node_var ',' natural ')'
+                    | formula ("∥" formula)*
+                    | 'splitEqs' '(' natural ')'
+    node_var       := ['#'] identifier ['.' natural] [':' 'node']
+    natural_sub    := ('₀'|'₁'|'₂'|'₃'|'₄'|'₅'|'₆'|'₇'|'₈'|'₉')+
 
 Formal comments are used to make the input more readable. In contrast
 to `/*...*/` and `//...` comments, formal comments are stored and output
@@ -105,19 +131,22 @@ use an undefined function symbol. This results in an error message pointing to
 a position slightly before the actual use of the function due to some
 ambiguity in the grammar.
 
-We provide special syntax for tuples, multiplications, exponentiation, nullary
-and binary function symbols. An n-ary tuple `<t1,...,tn>` is parsed as n-ary,
-right-associative application of pairing. Multiplication and exponentiation
-are parsed left-associatively. For a binary operator `enc` you can write
-`enc{m}k` or `enc(m,k)`. For nullary function symbols, there is no need to
-write `nullary()`. Note that the number of arguments of an n-ary function
-application must agree with the arity given in the function definition.
+We provide special syntax for tuples, multisets, xors, multiplications,
+exponentiation, nullary and binary function symbols. An n-ary tuple
+`<t1,...,tn>` is parsed as n-ary, right-associative application of pairing.
+Multiplication and exponentiation are parsed left-associatively. For a binary
+operator `enc` you can write `enc{m}k` or `enc(m,k)`. For nullary function
+symbols, there is no need to write `nullary()`. Note that the number of
+arguments of an n-ary function application must agree with the arity given in
+the function definition.
 
-    tupleterm := multterm list
+    tupleterm := '<' msetterm (',' msetterm)* '>'
+    msetterm  := xorterm ('+' xorterm)*
+    xorterm   := multterm (('XOR' | ⊕) multterm)*
     multterm  := expterm ('*' expterm)*
     expterm   := term    ('^' term   )*
-    term      := '<' tupleterm '>'     // n-ary right-associative pairing
-               | '(' multterm ')'      // a nested term
+    term      := tupleterm             // n-ary right-associative pairing
+               | '(' msetterm ')'      // a nested term
                | nullary_fun
                | binary_app
                | nary_app
@@ -128,12 +157,12 @@ application must agree with the arity given in the function definition.
     binary_fun  := <all-binary-functions-defined-up-to-here>
     nary_app    := nary_fun '(' multterm* ')'
 
-    literal := "'"  ident "'"      // a fixed, public name
-             | '$'  ident          // a variable of sort 'pub'
-             | "~'" ident "'"      // a fixed, fresh name
-             | "~"  ident          // a variable of sort 'fresh'
-             | "#"  ident          // a variable of sort 'temp'
-             | ident               // a variable of sort 'msg'
+    literal     := "'"  ident "'" // a fixed, public name
+                 | "~'" ident "'" // a fixed, fresh name
+                 | nonnode_var    // a non-temporal variable
+    nonnode_var := ['$'] identifier ['.' natural] [':' 'pub']   // 'pub' sort
+                 | ['~'] identifier ['.' natural] [':' 'fresh'] // 'fresh' sort
+                 | msg_var                                      // 'msg' sort
 
 Facts do not have to be defined up-front. This will probably change once we
 implement user-defined sorts. Facts prefixed with `!` are persistent facts.
@@ -144,35 +173,32 @@ KU-facts have arity 2. Their first argument is used to track the
 exponentiation tags. See the `loops/Crypto_API_Simple.spthy` example for more
 information.
 
-    facts      := fact list
-    fact       := ['!'] ident '(' multterm list ')' [fact_attrs]
-    fact_attrs := '[' fact_attr (',' fact_attr)* ']'
-    fact_attr  := '+' | '-' | 'no_precomp'
+    facts := fact list
+    fact := ['!'] ident '(' [msetterm (',' msetterm)*] ')'
 
 Formulas are trace formulas as described previously. Note that we are a bit
 more liberal with respect to guardedness. We accept a conjunction of atoms as
 guards.
 
-    formula   := atom | '(' iff ')' | ( 'All' | 'Ex' ) ident+ '.' iff
-    iff       := imp '<=>' imp
-    imp       := disjuncts '==>' disjuncts
-    disjuncts := conjuncts ('|' disjuncts)+  // left-associative
-    conjuncts := negation  ('&' conjuncts)+  // left-associative
-    negation  := 'not' formula
+    formula     := imp [('<=>' | '⇔') imp]
+    imp         := disjunction [('==>' | '⇒') imp]
+    disjunction := conjunction (('|' | '∨') conjunction)* // left-associative
+    conjunction := negation (('&' | '∧') negation)*       // left-associative
+    negation    := ['not' | '¬'] atom
+    atom        := ⊥ | 'F' | ⊤ | 'T'        // true or false
+                 | '(' formula ')'          // nested formula
+                 | 'last' '(' node_var ')'  // 'last' temporal variable for induction
+                 | fact '@' node_var        // action
+                 | node_var '<' node_var    // ordering of temporal variables
+                 | msetterm '=' msetterm    // equality of terms
+                 | node_var '=' node_var    // equality of temporal variables
+                 | ('Ex' | '∃' | 'All' | ∀) 
+                    lvar (',' lvar)* '.' formula //quantified formula
 
-    atom := tvar '<' tvar              // ordering of temporal variables
-          | '#' ident '=' '#' ident    // equality between temporal variables
-          | multterm  '=' multterm     // equality between terms
-          | fact '@' tvar              // action
-          | 'T'                        // true
-          | 'F'                        // false
-          | '(' formula ')'            // nested formula
-
-    // Where unambiguous the '#' sort prefix can be dropped.
-    tvar := ['#'] ident
-
-Identifiers always start with a character. Moreover, they must not be one of the
-reserved keywords `let`, `in`, or `rule`.
-
-    ident := alpha (alpha | digit)*
+Identifiers always start with a letter or number, and may contain underscores
+after the first character. Moreover, they must not be one of the
+reserved keywords `let`, `in`, or `rule`. Although identifiers beginning with
+a number are valid, they are not allowed as the names of rules or facts which
+must begin with a letter.
+    ident := alphaNum (alphaNum | '_')*
 

--- a/src/014_syntax_description.md
+++ b/src/014_syntax_description.md
@@ -27,9 +27,9 @@ only parse function applications of defined functions.
     equations      := 'equations' ':' equation (',' equation)*
     equation       := (term '=' term)
 
-Note that the equations must be subterm-convergent, and do not allow the use
+Note that the equations must be convergent and have the Finite Variant Property (FVP), and do not allow the use
 of fixed public names in the terms. Tamarin provides built-in
-sets of function definitions and subterm convergent equations. They are
+sets of function definitions and equations. They are
 expanded upon parsing and you can therefore inspect them by pretty printing
 the file using `tamarin-prover your_file.spthy`. The built-in `diffie-hellman`
 is special. It refers to the equations given in Section [Cryptographic

--- a/src/014_syntax_description.md
+++ b/src/014_syntax_description.md
@@ -95,7 +95,6 @@ quantifier.
     lemma_attrs      := '[' ('sources' | 'reuse' | 'use_induction' | 
                              'hide_lemma=' ident | 'heuristic=' ident) ']'
     trace_quantifier := 'all-traces' | 'exists-trace'
-    proof            := ... a proof as output by the Tamarin prover ..
 
 In observational equivalence mode, lemmas can be associated to one side.
 
@@ -117,7 +116,8 @@ It indicates the proof method used at each step, which may include multiple case
                     | '(' node_var ',' natural ')' '~~>' '(' node_var ',' natural ')'
                     | formula ("∥" formula)*
                     | 'splitEqs' '(' natural ')'
-    node_var       := ['#'] identifier ['.' natural] [':' 'node']
+    node_var       := ['#'] identifier ['.' natural]      // temporal sort prefix
+                    | identifier ['.' natural] ':' 'node' // temporal sort suffix
     natural_sub    := ('₀'|'₁'|'₂'|'₃'|'₄'|'₅'|'₆'|'₇'|'₈'|'₉')+
 
 Formal comments are used to make the input more readable. In contrast
@@ -160,9 +160,11 @@ the function definition.
     literal     := "'"  ident "'" // a fixed, public name
                  | "~'" ident "'" // a fixed, fresh name
                  | nonnode_var    // a non-temporal variable
-    nonnode_var := ['$'] identifier ['.' natural] [':' 'pub']   // 'pub' sort
-                 | ['~'] identifier ['.' natural] [':' 'fresh'] // 'fresh' sort
-                 | msg_var                                      // 'msg' sort
+    nonnode_var := ['$'] identifier ['.' natural]         // 'pub' sort prefix
+                 | identifier ['.' natural] ':' 'pub'     // 'pub' sort suffix
+                 | ['~'] identifier ['.' natural]         // 'fresh' sort prefix
+                 | identifier ['.' natural] ':' 'fresh'   // 'fresh' sort suffix
+                 | msg_var                                // 'msg' sort
 
 Facts do not have to be defined up-front. This will probably change once we
 implement user-defined sorts. Facts prefixed with `!` are persistent facts.
@@ -185,20 +187,21 @@ guards.
     disjunction := conjunction (('|' | '∨') conjunction)* // left-associative
     conjunction := negation (('&' | '∧') negation)*       // left-associative
     negation    := ['not' | '¬'] atom
-    atom        := ⊥ | 'F' | ⊤ | 'T'        // true or false
+    atom        := '⊥' | 'F' | '⊤' | 'T'        // true or false
                  | '(' formula ')'          // nested formula
                  | 'last' '(' node_var ')'  // 'last' temporal variable for induction
                  | fact '@' node_var        // action
                  | node_var '<' node_var    // ordering of temporal variables
                  | msetterm '=' msetterm    // equality of terms
                  | node_var '=' node_var    // equality of temporal variables
-                 | ('Ex' | '∃' | 'All' | ∀) 
-                    lvar (',' lvar)* '.' formula //quantified formula
+                 | ('Ex' | '∃' | 'All' | '∀') // quantified formula
+                    lvar+ '.' formula
+    lvar        := node_var | nonnode_var
 
 Identifiers always start with a letter or number, and may contain underscores
 after the first character. Moreover, they must not be one of the
 reserved keywords `let`, `in`, or `rule`. Although identifiers beginning with
-a number are valid, they are not allowed as the names of rules or facts which
-must begin with a letter.
+a number are valid, they are not allowed as the names of facts (which
+must begin with an upper-case letter).
     ident := alphaNum (alphaNum | '_')*
 

--- a/src/014_syntax_description.md
+++ b/src/014_syntax_description.md
@@ -54,7 +54,7 @@ specified in the body of the theory.
     rule_attrs := '[' rule_attr (',' rule_attr)* ']'
     rule_attr  := ('color=' | 'colour=') hexcolor
     let_block  := 'let' (msg_var '=' msetterm)+ 'in'
-    msg_var    := identifier ['.' natural] [':' 'msg']
+    msg_var    := ident ['.' natural] [':' 'msg']
 
 Rule annotations do not influence the rule's semantics. A color is represented
 as a triplet of 8 bit hexadecimal values optionally
@@ -107,8 +107,8 @@ It indicates the proof method used at each step, which may include multiple case
 
     proof_skeleton :=  'SOLVED' | 'by' proof_method
                     | proof_method proof_skeleton
-                    | proof_method 'case' identifier proof_skeleton
-                        ('next 'case' identifier proof_skeleton)* 'qed'
+                    | proof_method 'case' ident proof_skeleton
+                        ('next 'case' ident proof_skeleton)* 'qed'
     proof_method   := 'sorry' | 'simplify' | 'solve '(' goal ')' |
                       'contradiction' | 'induction'
     goal           :=  fact "▶" natural_subscr node_var
@@ -116,8 +116,9 @@ It indicates the proof method used at each step, which may include multiple case
                     | '(' node_var ',' natural ')' '~~>' '(' node_var ',' natural ')'
                     | formula ("∥" formula)*
                     | 'splitEqs' '(' natural ')'
-    node_var       := ['#'] identifier ['.' natural]      // temporal sort prefix
-                    | identifier ['.' natural] ':' 'node' // temporal sort suffix
+    node_var       := ['#'] ident ['.' natural]      // temporal sort prefix
+                    | ident ['.' natural] ':' 'node' // temporal sort suffix
+    natural        := digit+
     natural_sub    := ('₀'|'₁'|'₂'|'₃'|'₄'|'₅'|'₆'|'₇'|'₈'|'₉')+
 
 Formal comments are used to make the input more readable. In contrast
@@ -160,10 +161,10 @@ the function definition.
     literal     := "'"  ident "'" // a fixed, public name
                  | "~'" ident "'" // a fixed, fresh name
                  | nonnode_var    // a non-temporal variable
-    nonnode_var := ['$'] identifier ['.' natural]         // 'pub' sort prefix
-                 | identifier ['.' natural] ':' 'pub'     // 'pub' sort suffix
-                 | ['~'] identifier ['.' natural]         // 'fresh' sort prefix
-                 | identifier ['.' natural] ':' 'fresh'   // 'fresh' sort suffix
+    nonnode_var := ['$'] ident ['.' natural]         // 'pub' sort prefix
+                 | ident ['.' natural] ':' 'pub'     // 'pub' sort suffix
+                 | ['~'] ident ['.' natural]         // 'fresh' sort prefix
+                 | ident ['.' natural] ':' 'fresh'   // 'fresh' sort suffix
                  | msg_var                                // 'msg' sort
 
 Facts do not have to be defined up-front. This will probably change once we
@@ -175,7 +176,7 @@ KU-facts have arity 2. Their first argument is used to track the
 exponentiation tags. See the `loops/Crypto_API_Simple.spthy` example for more
 information.
 
-    facts := fact list
+    facts := fact (',' fact)*
     fact := ['!'] ident '(' [msetterm (',' msetterm)*] ')'
 
 Formulas are trace formulas as described previously. Note that we are a bit
@@ -195,7 +196,8 @@ guards.
                  | msetterm '=' msetterm    // equality of terms
                  | node_var '=' node_var    // equality of temporal variables
                  | ('Ex' | '∃' | 'All' | '∀') // quantified formula
-                    lvar+ '.' formula
+                        lvar+ '.' formula
+
     lvar        := node_var | nonnode_var
 
 Identifiers always start with a letter or number, and may contain underscores


### PR DESCRIPTION
Alright here we go. Someone please give this a proof read, since staring at grammars long enough tends to induce blindness.

- switched 'list' for explicit definition
- added explicit definitions for msg_var, node_var, sorted vars, and proof skeletons
- body fixed, since an empty body is in fact a valid theory
- function symbols allow '[private]' (could add an associated explanation in there)
- clarified that equations do not allow the use of fixed public names
- added four built-ins that were not previously included
- fixed definition of rule and lemma to allow modulo E/modulo AC
- definition of let block was incorrect, it allows for any message sort var on the LHS not just an ident, and an msetterm in the RHS
- added 'heuristic=' lemma attribute
- added definitions for msetterm, xorterm, and fixed references to multterm
- literals do not allow for node variables. They also allow for sort to be defined by a suffix instead of by prefix
- Formulas were defined incorrectly in several ways
    - the RHS of an implication can be an implication
    - timepoints do not need to be prefixed by '#', they can be suffixed by ':node'
    - a quantification can be over any lvars, not just idents
    - several alternative unicode symbols were missing
    - 'last' was missing
    - the definition previous required all formulas be negated ('not' was not optional)
    - the definition previously required all formulas be an if and only if
    - conjuncts and disjuncts do not allow for a nested conjunct (resp. disjunct) on the RHS
- Idents allow for numbers in the first position, and underscores after that. The requirement to begin with an upper-case letter is specific to facts, I believe
