### PR TITLE
Unbreak on machines with python3 as default

### DIFF
--- a/filter.py
+++ b/filter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 


### PR DESCRIPTION
On modern machines, python3 is the default interpreter for python
code, i.e. `/usr/bin/env python` executes python3. This PR
explicitly sets the interpreter to python2.