### PR TITLE
Add atom to syntax-highlighting support

### DIFF
--- a/src/002_installation.md
+++ b/src/002_installation.md
@@ -137,6 +137,11 @@ The [spthy.el](https://github.com/tamarin-prover/tamarin-prover/blob/develop/etc
 implements a SPTHY major mode. You can load it with `M-x load-file`, or add it to your `.emacs` in
 your favourite way.
 
+#### Atom
+
+The [language-tamarin](https://atom.io/packages/language-tamarin) package provides Tamarin syntax
+highlighting for Atom. To install it, run `apm install language-tamarin`.
+
 FAQ
 ---
 


### PR DESCRIPTION
This PR adds a note to the installation guide that there also exists syntax-highlighting support for atom.