### PR TITLE
Updated discussion of loop-breakers and annotation propagation

### DIFF
--- a/src/007_precomputation.md
+++ b/src/007_precomputation.md
@@ -146,4 +146,24 @@ with a restriction. But, we should ensure that the resulting model is the
 one we want; so use this with care.
 
 
+Loop breakers {#sec:loopbreakers}
+-----------
+During the precomputation phase, Tamarin determines a minimal set of 'loop-breakers',
+which are premises that can be excluded from the general precomputation of all premise goals 
+to prevent looping. Specifically, the set of loop breakers is a minimal set of premises
+that can be excluded to make the directed graph of rules, when connected from conclusions
+to premises, acyclic.
 
+It is important to note that there is often no unique minimal set of loop-breakers. The
+loop-breaker computation is deterministic for a given set of rules, but a change to
+the set of rules may result in different premises being considered loop-breakers. As such,
+you may find that a small change or addition of a rule to your model can result in changes
+to how some seemingly unrelated properties are solved.
+
+It is possible to manually break loops in particular places by annotating the relevant
+premise with the `no_precomp` annotation. These premises will then be excluded when computing
+loop-breakers over the rule set, and will not have their sources precomputed.
+For more on fact annotations, see 
+[Fact Annotations](009_advanced-features.html#sec:fact-annotations).
+
+--------

--- a/src/009_advanced-features.md
+++ b/src/009_advanced-features.md
@@ -112,6 +112,12 @@ with a rule conclusion containing `A(x)`. This allows multiple instances
 of the same fact to be solved with different priorities by annotating them
 differently.
 
+When an `In()` premise is annotated, the annotations are propagated up
+to the corresponding `!KU()` goals. For example, the premise `In(f(x))[+]`
+will generate a `!KU(f(x))[+]` goal that will be solved with high priority,
+while the premise `In(<y,g(y,z)>)[-]` will generate `!KU(y)[-]` and `!KU(g(y,z))[-]`
+goals to be solved with low priority.
+
 The `+` and `-` annotations can also be used to prioritize actions.
 For example, A reusable lemma of the form
 ```
@@ -126,13 +132,15 @@ respectively. Note however that these prefixes must apply to every instance
 of the fact, as a fact `F_A(x)` cannot unify with a fact `A(x)`.
 
 Facts in rule premises can also be annotated with `no_precomp` to prevent the
-tool from precomputing their sources.
-Use of the `no_precomp` annotation in key places can be very
-useful for reducing the precomputation time required to load large models, however
-it should be used sparingly. Preventing the precomputation of sources for a premise
-that is solved frequently will typically slow down the tool, as it must solve the
-premise each time instead of directly applying precomputed sources. Note also that
-using this annotation may cause partial deconstructions if the source of a premise
+tool from precomputing their sources, and to prevent them from being considered
+during the computation of loop-breakers.
+Use of the `no_precomp` annotation allows the modeller to manually control how
+loops are broken, or can be used to reduce
+the precomputation time required to load large models. Note, however
+that preventing the precomputation of sources for a premise
+that is solved frequently will typically slow down the tool, as there will be no
+precomputed sources to apply. Using this annotation may also cause 
+partial deconstructions if the source of a premise
 was necessary to compute a full deconstruction.
 
 The `no_precomp` annotation can be used in combination with heuristic annotations


### PR DESCRIPTION
Recent discussions made me realize that there were a couple undocumented features that are hugely helpful to understand for large models.
1) You can annotated `In()` facts with heuristic priority and it will be propagated up to the resulting `!KU()` goals.
2) The computation of loop breakers means that small changes to other parts of a model changing the way (or even if) a particular lemma can be autoproven by changing the set of computed loop-breakers, and the `no_precomp` annotation lets you manually break loops instead if you know where the best place to break them is.

These are things which exist in Tamarin currently and are undocumented, so this is not tied to an open tamarin-prover PR.

This was thrown together pretty quickly so comments (and especially questions, if it's unclear!) are very welcome.