### PR TITLE
Fix linux sublime editor install instructions re: Issue 73

### DIFF
--- a/src/002_installation.md
+++ b/src/002_installation.md
@@ -128,11 +128,11 @@ editor-sublime can be install in two ways:
 
 The first and preferred method is with [PackageControl.io](https://packagecontrol.io/). editor-sublime can now be installed via the sublime package manager. See the [install](https://packagecontrol.io/installation) and [usage](https://packagecontrol.io/docs/usage) documentation, then search and install Tamarin​Prover.
 
-Alternatively it can be installed from source. For Linux / OS X this process can be followed. We assume you have
+Alternatively it can be installed from source. For Linux / macOS this process can be followed. We assume you have
 the `git` tool installed.
 
 1. Change Directory to Sublime Text packages directory:
-    + Mac OS X: `cd ~/Library/Application\ Support/Sublime\ Text\ 3/Packages/`
+    + macOS: `cd ~/Library/Application\ Support/Sublime\ Text\ 3/Packages/`
     + Linux: `cd ~/.config/sublime-text-3/Packages/`
 
 2. Clone the directory into the Packages folder.

--- a/src/002_installation.md
+++ b/src/002_installation.md
@@ -133,13 +133,13 @@ the `git` tool installed.
 
 1. Change Directory to Sublime Text packages directory:
     + Mac OS X: `cd ~/Library/Application\ Support/Sublime\ Text\ 3/Packages/`
-    + Linux: `~/.Sublime\ Text\ 3/Packages/`
+    + Linux: `~/.config/sublime-text-3/Packages/`
 
-2. Pull directory into Packages folder.
-    + SSH: `git pull git@github.com:tamarin-prover/editor-sublime.git`
-    + HTTPS: `git pull https://github.com/tamarin-prover/editor-sublime.git`
+2. Clone the directory into the Packages folder.
+    + SSH: `git clone git@github.com:tamarin-prover/editor-sublime.git`
+    + HTTPS: `git clone https://github.com/tamarin-prover/editor-sublime.git`
 
-3. Open Sublime and bottom right syntaxes 'Tamarin' should be in the list.
+3. Close and re-open Sublime, and in the bottom right list of syntaxes 'Tamarin' should now be in the list.
 
 *Please be aware that this plugin is under active development and as such, several of the features are still implemented in a prototypical manner. If you experience any problems or have any questions on running any parts of the plug-in please [visit the project GitHub page](https://github.com/tamarin-prover/editor-sublime).*
 

--- a/src/002_installation.md
+++ b/src/002_installation.md
@@ -133,7 +133,7 @@ the `git` tool installed.
 
 1. Change Directory to Sublime Text packages directory:
     + Mac OS X: `cd ~/Library/Application\ Support/Sublime\ Text\ 3/Packages/`
-    + Linux: `~/.config/sublime-text-3/Packages/`
+    + Linux: `cd ~/.config/sublime-text-3/Packages/`
 
 2. Clone the directory into the Packages folder.
     + SSH: `git clone git@github.com:tamarin-prover/editor-sublime.git`


### PR DESCRIPTION
As per Issue #73, fix the Sublime Text editor syntax highlighting instructions in the manual.

Thanks,

Martin