### PR TITLE
Fix broken internal links in manual as per Issue 72

### DIFF
--- a/src/001_introduction.md
+++ b/src/001_introduction.md
@@ -104,27 +104,30 @@ technicalities. Then, we systematically build up the technical
 background a user needs, by first presenting the cryptographic
 messages in Section [Cryptographic
 Messages](004_cryptographic-messages.html#equational-theories), followed by
-the modeling approach in Section [Model
-Specification](005_protocol-specification.html#sec:model-specification) and
-the property specification in Section [Property
-Specification](006_property-specification.html#sec:property_specification).
+two different possible modeling approaches in Sections 5 and 6, covering
+[Protocol Specification using
+Rules](005_protocol-specification-rules.html#sec:model-specification)
+and [Protocol Specification using
+Processes](006_protocol-specification-processes.html#sec:model-specification-proc).
+Property specification is then covered in Section [Property
+Specification](007_property-specification.html#sec:property_specification).
 
 We then continue with information on precomputation in Section
-[Precomputation](007_precomputation.html#sec:precomputation) and
+[Precomputation](008_precomputation.html#sec:precomputation) and
 possible modeling issues in Section [Modeling
-Issues](008_modeling-issues.html#sec:modeling-issues). Afterwards,
+Issues](009_modeling-issues.html#sec:modeling-issues). Afterwards,
 advanced features for experienced users are described in Section
 [Advanced
-Features](009_advanced-features.html#sec:advanced-features). We have a
+Features](010_advanced-features.html#sec:advanced-features). We have a
 list of completed case studies in Section [Case
-Studies](010_case-studies.html#sec:case-studies). Alternative input
+Studies](011_case-studies.html#sec:case-studies). Alternative input
 toolchains are described in Section
-[Toolchains](011_toolchains.html#sec:tool-chains). Limitations are
+[Toolchains](012_toolchains.html#sec:tool-chains). Limitations are
 described in Section
-[Limitations](012_limitations.html#sec:limitations). We conclude the
+[Limitations](013_limitations.html#sec:limitations). We conclude the
 manual with contact information and further reading in [Contact
 Information and Further
-Reading](013_contact-and-further-reading.html#sec:contact).
+Reading](014_contact-and-further-reading.html#sec:contact).
 
 
 License

--- a/src/003_example.md
+++ b/src/003_example.md
@@ -78,7 +78,7 @@ default Tamarin setup, there is only one public channel modeling the network
 controlled by the adversary, i.e., the adversary receives all messages from the
 `Out( )` facts, and generates the protocol's inputs in the `In( )` facts.
 Private channels can be added if required, see [Channel
-Models](009_advanced-features.html#sec:channel-models) for details.]
+Models](010_advanced-features.html#sec:channel-models) for details.]
 
 The example starts with the model of a public key infrastructure (PKI). Again, 
 we use facts to store information about the state given by their arguments. The rules 
@@ -94,7 +94,7 @@ modeling the registration of a public key:
 Here the only premise is an instance of the `Fr` fact. The `Fr` fact is
 a built-in fact that denotes a freshly generated name. This mechanism is used to
 model random numbers such as nonces or keys (see [Model
-Specification](005_protocol-specification.html#sec:model-specification) for
+Specification](005_protocol-specification-rules.html#sec:model-specification) for
 details).
 
 In Tamarin, the sort of a variable is expressed using prefixes:
@@ -123,7 +123,7 @@ In the example, we allow the adversary to retrieve any public key
 using the following rule. Essentially, it reads a public-key database
 entry and sends the public key to the network using the built-in fact
 `Out`, which denotes sending a message to the network (see the section on 
-[Model Specification](005_protocol-specification.html#sec:model-specification)
+[Model Specification](005_protocol-specification-rules.html#sec:model-specification)
 for more information).
 
 ~~~~ {.tamarin slice="code/FirstExample.spthy" lower=23 upper=26}
@@ -238,7 +238,7 @@ you will then see the following output on the command line:
 At this point, if there were any syntax or wellformedness errors (for example if
 the same fact is used with different arities an error would be displayed) they
 would be displayed. See the part on [Modeling
-Issues](008_modeling-issues.html#sec:modeling-issues) for details on how to deal
+Issues](009_modeling-issues.html#sec:modeling-issues) for details on how to deal
 with such errors.
 
 However, there are no such errors in our example, and thus the above command

--- a/src/004_cryptographic-messages.md
+++ b/src/004_cryptographic-messages.md
@@ -127,7 +127,7 @@ In the following, we write `f/n` to denote that the function symbol `f` is
 : This theory models a public key encryption scheme. It defines the
   function symbols `aenc/2`, `adec/2`, and `pk/1`, which are
   related by the equation `adec(aenc(m, pk(sk)), sk) = m`.
-  Note that as described in [Syntax Description](014_syntax_description.html),
+  Note that as described in [Syntax Description](015_syntax_description.html),
   `aenc{x,y}pkB` is syntactic sugar for `aenc(<x,y>, pkB)`.
   <!-- This is otherwise not mentioned until Ch14: Syntax Description -->
 
@@ -204,7 +204,7 @@ x ⊕ x       = zero
 ``reliable-channel`:
 
 : This theory introduces support for reliable channel in the [process
-calculus](006_protocol-specification-processes.md).
+calculus](006_protocol-specification-processes.html).
 Messages on the channel (i.e., public name) `'r'` are guaranteed to arrive
 eventually. There is only one other channel, the public and unreliable channel
 `'c'`. Note that multiple reliable channels can be modelled using pattern matchting:

--- a/src/007_property-specification.md
+++ b/src/007_property-specification.md
@@ -15,7 +15,7 @@ system. The system's state is a multiset (bag) of facts and the
 initial system state is the empty multiset.  The rules define how the
 system can make a transition to a new state. The types of facts and
 their use are described in Section
-[Rules](005_protocol-specification.html#sec:rules). Here we focus on
+[Rules](005_protocol-specification-rules.html#sec:rules). Here we focus on
 the *action facts*, which are used to reason about a protocol's
 behaviour.
 
@@ -561,7 +561,7 @@ This means a number of things:
 
 Source lemmas are necessary whenever the analysis reports `partial
 deconstructions left` in the `Raw sources`. See section on [Open
-chains](007_precomputation.html#sec:openchains) for details on this.
+chains](008_precomputation.html#sec:openchains) for details on this.
 
 All `sources` lemmas are used only for the case distinctions and do not
 benefit from other lemmas being marked as `reuse`.

--- a/src/010_advanced-features.md
+++ b/src/010_advanced-features.md
@@ -303,7 +303,9 @@ We can model this protocol as follows.
 We state the nonce secrecy property for the 
 initiator and responder with the `nonce_secret_initiator` and the
 `nonce_secret_receiver` lemma, respectively. The lemma
-`message_authentication` specifies a [message authentication](006_property-specification.html#sec:message-authentication) property for the responder role. 
+`message_authentication` specifies a [message
+authentication](007_property-specification.html#sec:message-authentication)
+property for the responder role. 
 
 If we analyze the protocol with insecure channels, none of the
 properties hold because the adversary can learn the nonce sent by the

--- a/src/015_syntax_description.md
+++ b/src/015_syntax_description.md
@@ -47,7 +47,7 @@ enable it to parse terms containing exponentiations, e.g.,  g ^ x.
 
 A global heuristic sets the default heuristic that will be used when autoproving
 lemmas in the file. The specified heuristic can be any of those discussed in
-Section [Heuristics](009_advanced-features.html#sec:heuristics).
+Section [Heuristics](010_advanced-features.html#sec:heuristics).
 
     global_heuristic := 'heuristic' ':' heuristic
     heuristic        := alpha+
@@ -194,7 +194,7 @@ information.
 Fact annotations can be used to adjust the priority of corresponding
 goals in the heuristics, or influence the precomputation step performed by
 Tamarin, as described in
-Section [Advanced Features](009_advanced-features.html#sec:fact-annotations).
+Section [Advanced Features](010_advanced-features.html#sec:fact-annotations).
 
 Formulas are trace formulas as described previously. Note that we are a bit
 more liberal with respect to guardedness. We accept a conjunction of atoms as


### PR DESCRIPTION
As requested in Issue #72, this series of 6 commits (one per page) _should_ fix all the internal links following the split of Chapter 5 into two separate chapters (rules vs processes).

Please let me know if you think any of the new links don't work, or I've missed any! Could easily have made mistakes :-)

Thanks,

Martin