### PR TITLE
Remove title warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ anaconda-mode/
 
 
 # End of https://www.gitignore.io/api/emacs
+
+# tag file
+tags

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ tmp/%.md: src/%.md ./filter.py
 
 book/%.html: tmp/%.md $(TEMPLATE_HTML) latex_macros
 	$(PANDOC) -c $(STYLE) \
+	  --metadata title="Tamarin Manual" \
 	  --template $(TEMPLATE_HTML) -s -f $(IFORMAT) \
 	  --bibliography=src/manual.bib \
 	  -t html $(FLAGS) -o $@ $<


### PR DESCRIPTION
Remove title warning
```
[WARNING] This document format requires a nonempty <title> element.
  Defaulting to '012_toolchains' as the title.
  To specify a title, use 'title' in metadata or --metadata title="...".
 ```
 by setting a default title in the Makefile. Not sure if this has side-effects, but the warnings disappear and the HTML and PDF look alright to me.