### PR TITLE
Fix pandoc problems 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ anaconda-mode/
 
 
 # End of https://www.gitignore.io/api/emacs
+
+# tag file
+tags

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ pdf:	$(TMP) $(TEMPLATE_LATEX) latex_macros
 	echo "\n# References\n\n" >> tex/all.md
 	$(PANDOC) -f $(IFORMAT) \
 	  --template $(TEMPLATE_TEX) --pdf-engine=xelatex $(FLAGS) \
+	  --citeproc \
 	  --bibliography=src/manual.bib \
 	  -o tex/tamarin-manual.tex tex/all.md
 	make -C tex

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ book/%.html: tmp/%.md $(TEMPLATE_HTML) latex_macros
 	$(PANDOC) -c $(STYLE) \
 	  --metadata title="Tamarin Manual" \
 	  --template $(TEMPLATE_HTML) -s -f $(IFORMAT) \
+	  --citeproc \
 	  --bibliography=src/manual.bib \
 	  -t html $(FLAGS) -o $@ $<
 

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ tmp/%.md: src/%.md ./filter.py
 
 book/%.html: tmp/%.md $(TEMPLATE_HTML) latex_macros
 	$(PANDOC) -c $(STYLE) \
+	  --metadata title="Tamarin Manual" \
 	  --template $(TEMPLATE_HTML) -s -f $(IFORMAT) \
 	  --bibliography=src/manual.bib \
 	  -t html $(FLAGS) -o $@ $<

--- a/templates/template.latex
+++ b/templates/template.latex
@@ -21,7 +21,7 @@
 $if(csl-refs)$
 \newlength{\cslhangindent}
 \setlength{\cslhangindent}{1.5em}
-\newenvironment{cslreferences}%
+\newenvironment{CSLReferences}%
   {$if(csl-hanging-indent)$\setlength{\parindent}{0pt}%
   \everypar{\setlength{\hangindent}{\cslhangindent}}\ignorespaces$endif$}%
   {\par}


### PR DESCRIPTION
Hi! This PR contains two small changes:

1. Get rid of "missing field" warning messages by adding the `--metadata title=..` flag to `pandoc`
2. Update Makefile and latextemplate to be compatible with recent versions of `pandoc` (otherwise the bibliography does not work).
