### PR TITLE
Fixed typo in footnote 3

### DIFF
--- a/src/004_cryptographic-messages.md
+++ b/src/004_cryptographic-messages.md
@@ -200,7 +200,7 @@ x ⊕ x       = zero
 
 `multiset`:
 
-: This theory introduces the associative-commutative operator `++` which is usually used to model multisets^[In earlier versions of Tamarin, this operator was `+` wich is still supported but deprecated. The reason for this change is that in the end, we want to use `+` for addition on natural numbers (instead of the current `%+`).].
+: This theory introduces the associative-commutative operator `++` which is usually used to model multisets^[In earlier versions of Tamarin, this operator was `+` which is still supported but deprecated. The reason for this change is that in the end, we want to use `+` for addition on natural numbers (instead of the current `%+`).].
 
 `natural-numbers`:
 : This theory introduces the associative-commutative operator `%+` and the public constant `%1` which are used to model counters. It also introduces the sort `nat` with which variables can be annotated like the sort `pub $`: `n:nat` or `%n`. Furthermore, the operator `%+` only accepts terms of sort `nat` and is the only one to produce `nat` terms. This guarantees, that any term of sort `nat` is essentially a sum of `%1`. So all natural numbers are public knowledge which speeds up Tamarin as no attacker construction of a number has to be searched for.


### PR DESCRIPTION
Footnote 3 about the `++` operator reads *...this operator was `+` wich is still...*, fixed it.